### PR TITLE
Clarify enrollment status code in log

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,12 @@ func (c *Client) Enroll(ctx context.Context, logger logrus.FieldLogger, code str
 
 	// Log the request ID returned from the server
 	reqID := resp.Header.Get("X-Request-ID")
-	logger.WithFields(logrus.Fields{"reqID": reqID}).Info("Enrollment request complete")
+	l := logger.WithFields(logrus.Fields{"statusCode": resp.StatusCode, "reqID": reqID})
+	if resp.StatusCode != http.StatusOK {
+		l.Info("Enrollment request returned success code")
+	} else {
+		l.Error("Enrollment request returned error code")
+	}
 
 	// Decode the response
 	r := message.EnrollResponse{}


### PR DESCRIPTION
An error is returned in the console that ran enrollment, but dnclient logs look successful. This fixes that.