### PR TITLE
Add LongPollWait command

### DIFF
--- a/client.go
+++ b/client.go
@@ -168,6 +168,29 @@ func (c *Client) CheckForUpdate(ctx context.Context, creds Credentials) (bool, e
 	return result.Data.UpdateAvailable, nil
 }
 
+// LongPollWait sends a signed message to a DNClient API endpoint that will block, returning only
+// if there is an action the client should take before the timeout (config updates, debug commands)
+func (c *Client) LongPollWait(ctx context.Context, creds Credentials, supportedActions []string, clientInfo message.ClientInfo) (string, error) {
+	value, err := json.Marshal(message.LongPollWaitRequest{
+		Client:           clientInfo,
+		SupportedActions: supportedActions,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal DNClient message: %s", err)
+	}
+
+	respBody, err := c.postDNClient(ctx, message.LongPollWait, value, creds.HostID, creds.Counter, creds.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to post message to dnclient api: %w", err)
+	}
+	result := message.LongPollWaitResponseWrapper{}
+	err = json.Unmarshal(respBody, &result)
+	if err != nil {
+		return "", fmt.Errorf("failed to interpret API response: %s", err)
+	}
+	return result.Data.Action, nil
+}
+
 func (c *Client) DoUpdateWithTimeout(ctx context.Context, t time.Duration, creds Credentials) ([]byte, []byte, *Credentials, error) {
 	toCtx, cancel := context.WithTimeout(ctx, t)
 	defer cancel()

--- a/dnapitest/dnapitest.go
+++ b/dnapitest/dnapitest.go
@@ -155,7 +155,8 @@ func (s *Server) handlerDNClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if msg.Type == message.DoUpdate {
+	switch msg.Type {
+	case message.DoUpdate:
 		var updateKeys message.DoUpdateRequest
 		err = json.Unmarshal(msg.Value, &updateKeys)
 		if err != nil {
@@ -167,6 +168,41 @@ func (s *Server) handlerDNClient(w http.ResponseWriter, r *http.Request) {
 		if err := s.SetEdPubkey(updateKeys.EdPubkeyPEM); err != nil {
 			s.errors = append(s.errors, err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	case message.LongPollWait:
+		var longPoll message.LongPollWaitRequest
+		err = json.Unmarshal(msg.Value, &longPoll)
+		if err != nil {
+			s.errors = append(s.errors, fmt.Errorf("failed to unmarshal LongPollWaitRequest: %w", err))
+			http.Error(w, "failed to unmarshal LongPollWaitRequest", http.StatusInternalServerError)
+			return
+		}
+
+		if len(longPoll.SupportedActions) == 0 {
+			s.errors = append(s.errors, fmt.Errorf("no supported actions"))
+			http.Error(w, "no supported actions", http.StatusInternalServerError)
+			return
+		}
+
+		if len(longPoll.Client.Identifier) == 0 {
+			s.errors = append(s.errors, fmt.Errorf("no client identifier"))
+			http.Error(w, "no supported actions", http.StatusInternalServerError)
+			return
+		}
+		if len(longPoll.Client.Version) == 0 {
+			s.errors = append(s.errors, fmt.Errorf("no client version"))
+			http.Error(w, "no supported actions", http.StatusInternalServerError)
+			return
+		}
+		if len(longPoll.Client.OS) == 0 {
+			s.errors = append(s.errors, fmt.Errorf("no no client os"))
+			http.Error(w, "no supported actions", http.StatusInternalServerError)
+			return
+		}
+		if len(longPoll.Client.Architecture) == 0 {
+			s.errors = append(s.errors, fmt.Errorf("no client architecture"))
+			http.Error(w, "no supported actions", http.StatusInternalServerError)
 			return
 		}
 	}

--- a/message/message.go
+++ b/message/message.go
@@ -10,6 +10,7 @@ import (
 const (
 	CheckForUpdate = "CheckForUpdate"
 	DoUpdate       = "DoUpdate"
+	LongPollWait   = "LongPollWait"
 )
 
 // EndpointV1 is the version 1 DNClient API endpoint.
@@ -71,6 +72,29 @@ type DoUpdateResponse struct {
 	Counter     uint   `json:"counter"`
 	Nonce       []byte `json:"nonce"`
 	TrustedKeys []byte `json:"trustedKeys"`
+}
+
+// LongPollWaitResponseWrapper contains a response to LongPollWawit inside "data."
+type LongPollWaitResponseWrapper struct {
+	Data LongPollWaitResponse `json:"data"`
+}
+
+// LongPollWaitRequest is the request message associated with a LongPollWait call.
+type LongPollWaitRequest struct {
+	Client           ClientInfo `json:"client"`
+	SupportedActions []string   `json:"supportedActions"`
+}
+
+// DNClientLongPollResponse is the response message associated with a LongPollWait call.
+type LongPollWaitResponse struct {
+	Action string `json:"action"` // e.g. NoOp, StreamLogs, DoUpdate
+}
+
+type ClientInfo struct {
+	Identifier   string `json:"identifier"`
+	Version      string `json:"version"`
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
 }
 
 // EnrollEndpoint is the REST enrollment endpoint.


### PR DESCRIPTION
Mobile won't use this because long polling is likely bad for battery life, and we can't do constant long polling in the background anyway.

dnapitest is a helper package for packages which import dnapi. This PR adds code with the assumption that the client information should always be filled out by clients calling LongPollWait - this will be true of dnclient, at least.

However, on that bit... ClientInfo contains all the same info as the useragent, but in a more structured format. One downside to this approach when compared to the useragent approach is that both the outer and inner structs must be decoded to get to these fields. We currently have middleware on the dnclient endpoint that looks at the useragent and saves some analytics to Prometheus. This ClientInfo is not as useful for that purpose.

We also call `updateStaleMetadata` as part of `postDNClient` - again, this happens before LongPollWait message is decoded, so this information is not useful in that context. Although, we could refactor things so that `updateStaleMetadata` is only called from LongPollWait and CheckForUpdate (for mobile.)

Or we could drop this entire thing and continue using the useragent. Or move it into the unsigned dnclient message struct. Thoughts?