### PR TITLE
Additional LongPollWait supporting code

### DIFF
--- a/client.go
+++ b/client.go
@@ -278,32 +278,11 @@ func (c *Client) DoUpdate(ctx context.Context, creds Credentials) ([]byte, []byt
 func (c *Client) CommandResponse(ctx context.Context, creds Credentials, responseToken string, response any) error {
 	value, err := json.Marshal(message.CommandResponseRequest{
 		ResponseToken: responseToken,
+		Response:      response,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal DNClient message: %s", err)
 	}
-
-	jresp, err := json.Marshal(response)
-	if err != nil {
-		return fmt.Errorf("failed to marshal DNClient command response: %s", err)
-	}
-
-	postBody, err := SignRequestV1(message.CommandResponse, value, creds.HostID, creds.Counter, creds.PrivateKey)
-	if err != nil {
-		return nil
-	}
-	postBody = append(postBody, []byte("\n")...)
-	postBody = append(postBody, jresp...)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.dnServer+message.EndpointV1, bytes.NewReader(postBody))
-	if err != nil {
-		return err
-	}
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to call dnclient endpoint: %w", err)
-	}
-	defer resp.Body.Close()
 
 	_, err = c.postDNClient(ctx, message.CommandResponse, value, creds.HostID, creds.Counter, creds.PrivateKey)
 	return err

--- a/client.go
+++ b/client.go
@@ -34,9 +34,8 @@ func NewClient(useragent string, dnServer string) *Client {
 			Timeout: 1 * time.Minute,
 			Transport: &uaTransport{
 				T: &http.Transport{
-					Proxy:                 http.ProxyFromEnvironment,
-					TLSHandshakeTimeout:   10 * time.Second,
-					ResponseHeaderTimeout: 10 * time.Second,
+					Proxy:               http.ProxyFromEnvironment,
+					TLSHandshakeTimeout: 10 * time.Second,
 					DialContext: (&net.Dialer{
 						Timeout: 10 * time.Second,
 					}).DialContext,
@@ -48,9 +47,8 @@ func NewClient(useragent string, dnServer string) *Client {
 			Timeout: 15 * time.Minute,
 			Transport: &uaTransport{
 				T: &http.Transport{
-					Proxy:                 http.ProxyFromEnvironment,
-					TLSHandshakeTimeout:   10 * time.Second,
-					ResponseHeaderTimeout: 10 * time.Second,
+					Proxy:               http.ProxyFromEnvironment,
+					TLSHandshakeTimeout: 10 * time.Second,
 					DialContext: (&net.Dialer{
 						Timeout: 10 * time.Second,
 					}).DialContext,
@@ -180,24 +178,24 @@ func (c *Client) CheckForUpdate(ctx context.Context, creds Credentials) (bool, e
 
 // LongPollWait sends a signed message to a DNClient API endpoint that will block, returning only
 // if there is an action the client should take before the timeout (config updates, debug commands)
-func (c *Client) LongPollWait(ctx context.Context, creds Credentials, supportedActions []string) (string, map[string]any, string, error) {
+func (c *Client) LongPollWait(ctx context.Context, creds Credentials, supportedActions []string) (*message.LongPollWaitResponse, error) {
 	value, err := json.Marshal(message.LongPollWaitRequest{
 		SupportedActions: supportedActions,
 	})
 	if err != nil {
-		return "", nil, "", fmt.Errorf("failed to marshal DNClient message: %s", err)
+		return nil, fmt.Errorf("failed to marshal DNClient message: %s", err)
 	}
 
 	respBody, err := c.postDNClient(ctx, message.LongPollWait, value, creds.HostID, creds.Counter, creds.PrivateKey)
 	if err != nil {
-		return "", nil, "", fmt.Errorf("failed to post message to dnclient api: %w", err)
+		return nil, fmt.Errorf("failed to post message to dnclient api: %w", err)
 	}
 	result := message.LongPollWaitResponseWrapper{}
 	err = json.Unmarshal(respBody, &result)
 	if err != nil {
-		return "", nil, "", fmt.Errorf("failed to interpret API response: %s", err)
+		return nil, fmt.Errorf("failed to interpret API response: %s", err)
 	}
-	return result.Data.Action, result.Data.Args, result.Data.ResponseToken, nil
+	return &result.Data, nil
 }
 
 // DoUpdate sends a signed message to the DNClient API to fetch the new configuration update. During this call a new
@@ -277,6 +275,40 @@ func (c *Client) DoUpdate(ctx context.Context, creds Credentials) ([]byte, []byt
 	return result.Config, dhPrivkeyPEM, newCreds, nil
 }
 
+func (c *Client) CommandResponse(ctx context.Context, creds Credentials, responseToken string, response any) error {
+	value, err := json.Marshal(message.CommandResponseRequest{
+		ResponseToken: responseToken,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal DNClient message: %s", err)
+	}
+
+	jresp, err := json.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal DNClient command response: %s", err)
+	}
+
+	postBody, err := SignRequestV1(message.CommandResponse, value, creds.HostID, creds.Counter, creds.PrivateKey)
+	if err != nil {
+		return nil
+	}
+	postBody = append(postBody, []byte("\n")...)
+	postBody = append(postBody, jresp...)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.dnServer+message.EndpointV1, bytes.NewReader(postBody))
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call dnclient endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	_, err = c.postDNClient(ctx, message.CommandResponse, value, creds.HostID, creds.Counter, creds.PrivateKey)
+	return err
+}
+
 func (c *Client) StreamCommandResponse(ctx context.Context, creds Credentials, responseToken string) (*StreamController, error) {
 	value, err := json.Marshal(message.CommandResponseRequest{
 		ResponseToken: responseToken,
@@ -308,13 +340,11 @@ func (c *Client) streamingPostDNClient(ctx context.Context, reqType string, valu
 	sc := &StreamController{w: pw, done: done}
 
 	go func() {
-		defer func() {
-			close(done)
-		}()
+		defer close(done)
 
 		resp, err := c.streamingClient.Do(req)
 		if err != nil {
-			sc.err.Store(fmt.Errorf("failed to call dnclient endpoint: %s", err))
+			sc.err.Store(fmt.Errorf("failed to call dnclient endpoint: %w", err))
 			return
 		}
 		defer resp.Body.Close()
@@ -357,7 +387,7 @@ func (c *Client) postDNClient(ctx context.Context, reqType string, value []byte,
 	}
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call dnclient endpoint: %s", err)
+		return nil, fmt.Errorf("failed to call dnclient endpoint: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ type Client struct {
 func NewClient(useragent string, dnServer string) *Client {
 	return &Client{
 		client: &http.Client{
-			Timeout: 1 * time.Minute,
+			Timeout: 2 * time.Minute,
 			Transport: &uaTransport{
 				T: &http.Transport{
 					Proxy:               http.ProxyFromEnvironment,

--- a/client_test.go
+++ b/client_test.go
@@ -542,7 +542,7 @@ func TestTimeout(t *testing.T) {
 	useragent := "TestTimeout agent"
 	c := NewClient(useragent, ts.URL)
 	// The default timeout is 1 minutes. Assert the default value.
-	assert.Equal(t, c.client.Timeout, 1*time.Minute)
+	assert.Equal(t, c.client.Timeout, 2*time.Minute)
 	// The default streaming timeout is 15 minutes. Assert the default value.
 	assert.Equal(t, c.streamingClient.Timeout, 15*time.Minute)
 	// Overwrite the default value with a 10 millisecond timeout for test brevity.

--- a/dnapitest/dnapitest.go
+++ b/dnapitest/dnapitest.go
@@ -156,7 +156,7 @@ func (s *Server) handlerDNClient(w http.ResponseWriter, r *http.Request) {
 	// Require the expected request type, otherwise we have derailed.
 	if msg.Type != res.expectedType {
 		s.errors = append(s.errors, fmt.Errorf("%s is not expected message type %s", msg.Type, res.expectedType))
-		http.Error(w, "unexpected message type", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("unexpected message type %s, wanted %s", msg.Type, res.expectedType), http.StatusInternalServerError)
 		return
 	}
 

--- a/message/message.go
+++ b/message/message.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -87,9 +88,8 @@ type LongPollWaitRequest struct {
 
 // LongPollWaitResponse is the response message associated with a LongPollWait call.
 type LongPollWaitResponse struct {
-	Action        string                 `json:"action"` // e.g. NoOp, StreamLogs, DoUpdate
-	Args          map[string]interface{} `json:"args"`
-	ResponseToken string                 `json:"responseToken"`
+	Action        json.RawMessage `json:"action"` // e.g. NoOp, StreamLogs, DoUpdate
+	ResponseToken string          `json:"responseToken"`
 }
 
 // CommandResponseResponseWrapper contains a response to CommandResponse inside "data."
@@ -99,7 +99,8 @@ type CommandResponseResponseWrapper struct {
 
 // CommandResponseRequest is the request message associated with a CommandResponse call.
 type CommandResponseRequest struct {
-	ResponseToken string `json:"responseToken"`
+	ResponseToken string          `json:"responseToken"`
+	Response      json.RawMessage `json:"response"`
 }
 
 // DNClientCommandResponseResponse is the response message associated with a CommandResponse call.

--- a/message/message.go
+++ b/message/message.go
@@ -87,7 +87,9 @@ type LongPollWaitRequest struct {
 
 // LongPollWaitResponse is the response message associated with a LongPollWait call.
 type LongPollWaitResponse struct {
-	Action string `json:"action"` // e.g. NoOp, StreamLogs, DoUpdate
+	Action        string                 `json:"action"` // e.g. NoOp, StreamLogs, DoUpdate
+	Args          map[string]interface{} `json:"args"`
+	ResponseToken string                 `json:"responseToken"`
 }
 
 // CommandResponseResponseWrapper contains a response to CommandResponse inside "data."

--- a/message/message.go
+++ b/message/message.go
@@ -99,8 +99,8 @@ type CommandResponseResponseWrapper struct {
 
 // CommandResponseRequest is the request message associated with a CommandResponse call.
 type CommandResponseRequest struct {
-	ResponseToken string          `json:"responseToken"`
-	Response      json.RawMessage `json:"response"`
+	ResponseToken string `json:"responseToken"`
+	Response      any    `json:"response"`
 }
 
 // DNClientCommandResponseResponse is the response message associated with a CommandResponse call.


### PR DESCRIPTION
- Support for non-streaming CommandResponse
- Updated timeouts to support headers not being sent immediately
- Fix StreamController.Write behavior (error dampening can occur in dnclient)
- Defer Action unmarshalling and include ResponseToken in LongPollWait responses
- Include Response in CommandResponseRequest
- Wrap HTTP Do calls to allow callers to detect `context.Canceled` in the middle of a long poll request