### PR TITLE
Fix logic error causing panic storing nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -357,8 +357,9 @@ func (c *Client) streamingPostDNClient(ctx context.Context, reqType string, valu
 			}
 			if err := json.Unmarshal(respBody, &errors); err != nil {
 				sc.err.Store(fmt.Errorf("dnclient endpoint returned bad status code '%d', body: %s", resp.StatusCode, respBody))
+			} else {
+				sc.err.Store(errors.Errors.ToError())
 			}
-			sc.err.Store(errors.Errors.ToError())
 		}
 	}()
 


### PR DESCRIPTION
While writing a test I received the following error:

```
time="2024-06-18T23:14:56-04:00" level=info msg="update failed" error="failed to call defined networking: failed to make API call to Defined Networking: dnclient endpoint returned bad status code '500', body: unexpected request\n"
panic: sync/atomic: store of nil value into Value

goroutine 113 [running]:
sync/atomic.(*Value).Store(0x0?, {0x0, 0x0})
	/opt/homebrew/Cellar/go/1.22.4/libexec/src/sync/atomic/value.go:49 +0xec
github.com/DefinedNet/dnapi.(*Client).streamingPostDNClient.func1()
	/Users/jmaguire/go/pkg/mod/github.com/!defined!net/dnapi@v0.0.0-20240606181337-15680178c26a/client.go:353 +0x314
created by github.com/DefinedNet/dnapi.(*Client).streamingPostDNClient in goroutine 101
	/Users/jmaguire/go/pkg/mod/github.com/!defined!net/dnapi@v0.0.0-20240606181337-15680178c26a/client.go:326 +0x310
FAIL	github.com/DefinedNet/dnclient	0.212s
```

Basically, we try to decode a "derp" error when receiving a 500. If we fail to decode it, we store a "generic" error, otherwise we store the fancy typed error.

Except I forgot an "else" so even in error, we'd try to overwrite the generic error with a nil error. It's kind of lucky that atomics don't allow storing nil values, or we might've missed this.