### PR TITLE
Return APIErrors directly instead of as a stringified error

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,8 +164,8 @@ func (c *Client) Enroll(ctx context.Context, logger logrus.FieldLogger, code str
 	}
 
 	// Check for any errors returned by the API
-	if err := r.Errors; err != nil {
-		return nil, nil, nil, nil, err
+	if err := r.Errors.ToError(); err != nil {
+		return nil, nil, nil, nil, &APIError{e: fmt.Errorf("unexpected error during enrollment: %v", err), ReqID: reqID}
 	}
 
 	meta := &EnrollMeta{
@@ -412,7 +412,7 @@ func (c *Client) streamingPostDNClient(ctx context.Context, reqType string, valu
 			if err := json.Unmarshal(respBody, &errors); err != nil {
 				sc.err.Store(fmt.Errorf("dnclient endpoint returned bad status code '%d', body: %s", resp.StatusCode, respBody))
 			} else {
-				sc.err.Store(errors.Errors)
+				sc.err.Store(errors.Errors.ToError())
 			}
 		}
 	}()
@@ -459,7 +459,7 @@ func (c *Client) postDNClient(ctx context.Context, reqType string, value []byte,
 		if err := json.Unmarshal(respBody, &errors); err != nil {
 			return nil, fmt.Errorf("dnclient endpoint returned bad status code '%d', body: %s", resp.StatusCode, respBody)
 		}
-		return nil, errors.Errors
+		return nil, errors.Errors.ToError()
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -164,8 +164,8 @@ func (c *Client) Enroll(ctx context.Context, logger logrus.FieldLogger, code str
 	}
 
 	// Check for any errors returned by the API
-	if err := r.Errors.ToError(); err != nil {
-		return nil, nil, nil, nil, &APIError{e: fmt.Errorf("unexpected error during enrollment: %v", err), ReqID: reqID}
+	if err := r.Errors; err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	meta := &EnrollMeta{
@@ -412,7 +412,7 @@ func (c *Client) streamingPostDNClient(ctx context.Context, reqType string, valu
 			if err := json.Unmarshal(respBody, &errors); err != nil {
 				sc.err.Store(fmt.Errorf("dnclient endpoint returned bad status code '%d', body: %s", resp.StatusCode, respBody))
 			} else {
-				sc.err.Store(errors.Errors.ToError())
+				sc.err.Store(errors.Errors)
 			}
 		}
 	}()
@@ -459,7 +459,7 @@ func (c *Client) postDNClient(ctx context.Context, reqType string, value []byte,
 		if err := json.Unmarshal(respBody, &errors); err != nil {
 			return nil, fmt.Errorf("dnclient endpoint returned bad status code '%d', body: %s", resp.StatusCode, respBody)
 		}
-		return nil, errors.Errors.ToError()
+		return nil, errors.Errors
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -79,8 +79,8 @@ func (e *APIError) Unwrap() error {
 	return e.e
 }
 
-var InvalidCredentialsError = fmt.Errorf("invalid credentials")
-var InvalidCodeError = fmt.Errorf("invalid enrollment code")
+var ErrInvalidCredentials = fmt.Errorf("invalid credentials")
+var ErrInvalidCode = fmt.Errorf("invalid enrollment code")
 
 type EnrollMeta struct {
 	OrganizationID   string
@@ -163,7 +163,7 @@ func (c *Client) Enroll(ctx context.Context, logger logrus.FieldLogger, code str
 	// Check for *only* an "invalid code" error returned by the API
 	if len(r.Errors) == 1 {
 		if err := r.Errors[0]; err.Path == "code" && err.Code == "ERR_INVALID_VALUE" {
-			return nil, nil, nil, nil, &APIError{e: InvalidCodeError, ReqID: reqID}
+			return nil, nil, nil, nil, &APIError{e: ErrInvalidCode, ReqID: reqID}
 		}
 	}
 
@@ -408,7 +408,7 @@ func (c *Client) streamingPostDNClient(ctx context.Context, reqType string, valu
 		case http.StatusOK:
 			sc.respBytes = respBody
 		case http.StatusUnauthorized:
-			sc.err.Store(InvalidCredentialsError)
+			sc.err.Store(ErrInvalidCredentials)
 		default:
 			var errors struct {
 				Errors message.APIErrors
@@ -455,7 +455,7 @@ func (c *Client) postDNClient(ctx context.Context, reqType string, value []byte,
 	case http.StatusOK:
 		return respBody, nil
 	case http.StatusUnauthorized:
-		return nil, InvalidCredentialsError
+		return nil, ErrInvalidCredentials
 	default:
 		var errors struct {
 			Errors message.APIErrors

--- a/client_test.go
+++ b/client_test.go
@@ -237,8 +237,7 @@ func TestDoUpdate(t *testing.T) {
 	defer cancel()
 	_, err = c.CheckForUpdate(ctx, invalidCreds)
 	assert.Error(t, err)
-	invalidCredsErrorType := InvalidCredentialsError{}
-	assert.ErrorAs(t, err, &invalidCredsErrorType)
+	assert.ErrorAs(t, err, &InvalidCredentialsError)
 	serverErrs := ts.Errors() // This consumes/resets the server errors
 	require.Len(t, serverErrs, 1)
 
@@ -427,8 +426,7 @@ func TestDoUpdate_P256(t *testing.T) {
 	defer cancel()
 	_, err = c.CheckForUpdate(ctx, invalidCreds)
 	assert.Error(t, err)
-	invalidCredsErrorType := InvalidCredentialsError{}
-	assert.ErrorAs(t, err, &invalidCredsErrorType)
+	assert.ErrorAs(t, err, &InvalidCredentialsError)
 	serverErrs := ts.Errors() // This consumes/resets the server errors
 	require.Len(t, serverErrs, 1)
 

--- a/client_test.go
+++ b/client_test.go
@@ -237,7 +237,7 @@ func TestDoUpdate(t *testing.T) {
 	defer cancel()
 	_, err = c.CheckForUpdate(ctx, invalidCreds)
 	assert.Error(t, err)
-	assert.ErrorAs(t, err, &InvalidCredentialsError)
+	assert.ErrorIs(t, err, ErrInvalidCredentials)
 	serverErrs := ts.Errors() // This consumes/resets the server errors
 	require.Len(t, serverErrs, 1)
 
@@ -426,7 +426,7 @@ func TestDoUpdate_P256(t *testing.T) {
 	defer cancel()
 	_, err = c.CheckForUpdate(ctx, invalidCreds)
 	assert.Error(t, err)
-	assert.ErrorAs(t, err, &InvalidCredentialsError)
+	assert.ErrorIs(t, err, ErrInvalidCredentials)
 	serverErrs := ts.Errors() // This consumes/resets the server errors
 	require.Len(t, serverErrs, 1)
 

--- a/message/message.go
+++ b/message/message.go
@@ -167,9 +167,9 @@ type APIError struct {
 
 type APIErrors []APIError
 
-func (errs APIErrors) ToError() error {
+func (errs APIErrors) Error() string {
 	if len(errs) == 0 {
-		return nil
+		return ""
 	}
 
 	s := make([]string, len(errs))
@@ -177,7 +177,7 @@ func (errs APIErrors) ToError() error {
 		s[i] = errs[i].Message
 	}
 
-	return errors.New(strings.Join(s, ", "))
+	return strings.Join(s, ", ")
 }
 
 // NetworkCurve represents the network curve specified by the API.

--- a/message/message.go
+++ b/message/message.go
@@ -167,9 +167,9 @@ type APIError struct {
 
 type APIErrors []APIError
 
-func (errs APIErrors) Error() string {
+func (errs APIErrors) ToError() error {
 	if len(errs) == 0 {
-		return ""
+		return nil
 	}
 
 	s := make([]string, len(errs))
@@ -177,7 +177,7 @@ func (errs APIErrors) Error() string {
 		s[i] = errs[i].Message
 	}
 
-	return strings.Join(s, ", ")
+	return errors.New(strings.Join(s, ", "))
 }
 
 // NetworkCurve represents the network curve specified by the API.


### PR DESCRIPTION
This alters `ToError() error` to be `Error() string` to allow `APIErrors` to implement the Error interface.