### PR TITLE
message: remove unused ClientInfo struct

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -133,13 +133,6 @@ type CommandResponseRequest struct {
 // CommandResponseResponse is the response message associated with a CommandResponse call.
 type CommandResponseResponse struct{}
 
-type ClientInfo struct {
-	Identifier   string `json:"identifier"`
-	Version      string `json:"version"`
-	OS           string `json:"os"`
-	Architecture string `json:"architecture"`
-}
-
 // ReauthenticateRequest is the request sent for a Reauthenticate request.
 type ReauthenticateRequest struct {
 	// Add fields as needed


### PR DESCRIPTION
Spike cleanup found while investigating OS metadata collection (companion api PR incoming).

`message.ClientInfo` has no references in dnapi, api, or dnclient — client metadata travels via the User-Agent header instead (`dnclient/0.1.9 (MacOS; arch:arm64; supervised)`), parsed server-side per-request.

Note: this removes an exported type from a public module, so it's technically a breaking change for any external consumer — but GitHub code search turns up no external usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)