### PR TITLE
Omit zero-valued data from marshalled APIResponse

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -151,9 +151,14 @@ type ReauthenticateResponse struct {
 }
 
 // APIResponse is a standard format for the DN API. It does not apply to the DNClient API.
+// The API sends exactly one of data or errors, so marshalling omits whichever
+// is unset. Data requires omitzero (not omitempty) because omitempty never
+// omits a struct: a zero-valued Data emitted alongside errors has fields that
+// can fail validation on decode (such as NetworkCurve), masking the errors the
+// response was meant to carry.
 type APIResponse[T any] struct {
-	Data   T                 `json:"data"`
-	Errors APIResponseErrors `json:"errors"`
+	Data   T                 `json:"data,omitzero"`
+	Errors APIResponseErrors `json:"errors,omitempty"`
 }
 
 // APIResponseError represents a single error returned in an API error response.

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -1,0 +1,41 @@
+package message
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// An error-only APIResponse must round-trip without emitting a zero-valued
+// data object, whose empty curve would fail NetworkCurve validation on decode
+// and mask the errors.
+func TestAPIResponseErrorOnlyRoundTrip(t *testing.T) {
+	b, err := json.Marshal(APIResponse[EnrollResponseData]{
+		Errors: APIResponseErrors{{Code: "ERR_TEST", Message: "test error"}},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"data"`)
+
+	var r APIResponse[EnrollResponseData]
+	require.NoError(t, json.Unmarshal(b, &r))
+	require.EqualError(t, r.Errors.Err(), "test error")
+}
+
+// A data-only APIResponse must omit the errors key, matching the API.
+func TestAPIResponseDataOnlyOmitsErrors(t *testing.T) {
+	b, err := json.Marshal(APIResponse[EnrollResponseData]{
+		Data: EnrollResponseData{
+			HostID: "foobar",
+			// a valid curve is required for the decode below, as on the real API
+			Network: HostNetworkMetadata{Curve: NetworkCurve25519},
+		},
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"errors"`)
+
+	var r APIResponse[EnrollResponseData]
+	require.NoError(t, json.Unmarshal(b, &r))
+	require.NoError(t, r.Errors.Err())
+	require.Equal(t, "foobar", r.Data.HostID)
+}


### PR DESCRIPTION
## What

Tags `APIResponse.Data` with `omitzero` and `APIResponse.Errors` with `omitempty`, so marshalling omits whichever side is unset. Adds round-trip tests for both the error-only and data-only cases.

## Why

The API sends exactly one of `data` or `errors` - success responses have no `errors` key, and error responses have no `data` key. Go test servers marshalling an error-only `APIResponse` emitted a zero-valued `data` object alongside the errors. Its empty `network.curve` then failed `NetworkCurve` validation when the client decoded the response, turning the intended API errors into:

```
unexpected error during enrollment: error decoding JSON response: invalid network curve
body: {"data":{...},"errors":[{"code":"ERR_UNEXPECTED_HOSTNAME",...}]}
```