### PR TITLE
Fix Go caching in CI

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          # The built-in cache shares one key across every setup-go job in the
-          # repo; whichever job saves first locks the key to its contents. The
-          # explicit cache below has a job-specific key.
           cache: false
         id: go
 
@@ -34,8 +31,6 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          # goimports artifacts depend only on the toolchain and x/tools
-          # version, so a static key cannot go stale.
           key: gofmt-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             gofmt-go-

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -22,14 +22,23 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
+          # The built-in cache shares one key across every setup-go job in the
+          # repo; whichever job saves first locks the key to its contents. The
+          # explicit cache below has a job-specific key.
+          cache: false
         id: go
 
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+      - name: Restore Go caches
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gofmt1.22-${{ hashFiles('**/go.sum') }}
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # goimports artifacts depend only on the toolchain and x/tools
+          # version, so a static key cannot go stale.
+          key: gofmt-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-gofmt1.22-
+            gofmt-go-
 
       - name: Install goimports
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,25 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
+          # The built-in cache shares one key across every setup-go job in the
+          # repo; whichever job saves first locks the key to its contents. The
+          # explicit cache below has a job-specific key.
+          cache: false
         id: go
 
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+      - name: Restore Go caches
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go1.22-${{ hashFiles('**/go.sum') }}
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          # The per-commit suffix guarantees a primary-key miss so the post
+          # step saves a fresh cache (immutable keys cannot be updated), while
+          # restore-keys warms each run from the most recent prior commit.
+          key: test-go-${{ hashFiles('go.sum') }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-go1.22-
+            test-go-${{ hashFiles('go.sum') }}-
+            test-go-
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 #v9.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,10 @@ jobs:
           # The per-commit suffix guarantees a primary-key miss so the post
           # step saves a fresh cache (immutable keys cannot be updated), while
           # restore-keys warms each run from the most recent prior commit.
-          key: test-go-${{ hashFiles('go.sum') }}-${{ github.sha }}
+          key: test-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
           restore-keys: |
-            test-go-${{ hashFiles('go.sum') }}-
+            test-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}-
+            test-go-${{ steps.go.outputs.go-version }}-
             test-go-
 
       - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          # The built-in cache shares one key across every setup-go job in the
-          # repo; whichever job saves first locks the key to its contents. The
-          # explicit cache below has a job-specific key.
           cache: false
         id: go
 
@@ -37,9 +34,6 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          # The per-commit suffix guarantees a primary-key miss so the post
-          # step saves a fresh cache (immutable keys cannot be updated), while
-          # restore-keys warms each run from the most recent prior commit.
           key: test-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}-${{ github.sha }}
           restore-keys: |
             test-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum') }}-


### PR DESCRIPTION
Part of the org-wide fix for setup-go cache-key collisions (see DefinedNet/api#2220).